### PR TITLE
Add guest management features

### DIFF
--- a/src/app/dashboard/guests/page.tsx
+++ b/src/app/dashboard/guests/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
@@ -77,7 +77,15 @@ const guestFormSchema = z.object({
   name: z.string().min(1, { message: 'Name is required' }),
   email: z.string().email().optional().or(z.literal('')),
   phone: z.string().optional().or(z.literal('')),
+  category: z.enum(["bride's", "bridegroom's", 'shared', 'service']).default("bride's"),
+  relationship: z.enum(['family', 'friend', 'colleague', 'service']).default('friend'),
+  familyGroup: z.string().optional().or(z.literal('')),
+  headOfFamily: z.boolean().default(false),
   plusOneAllowed: z.boolean().default(false),
+  plusOneName: z.string().optional().or(z.literal('')),
+  invitedTo: z.array(z.string()).default([]),
+  invitationCode: z.string().optional().or(z.literal('')),
+  rsvpStatus: z.enum(['pending', 'accepted', 'declined']).default('pending'),
 });
 
 type GuestFormValues = z.infer<typeof guestFormSchema>;
@@ -93,6 +101,12 @@ export default function GuestsPage() {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingGuest, setEditingGuest] = useState<Guest | null>(null);
   const [saving, setSaving] = useState(false);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [filters, setFilters] = useState({
+    category: 'all',
+    relationship: 'all',
+    rsvpStatus: 'all',
+  });
 
   const form = useForm<GuestFormValues>({
     resolver: zodResolver(guestFormSchema),
@@ -100,9 +114,19 @@ export default function GuestsPage() {
       name: '',
       email: '',
       phone: '',
+      category: "bride's",
+      relationship: 'friend',
+      familyGroup: '',
+      headOfFamily: false,
       plusOneAllowed: false,
+      plusOneName: '',
+      invitedTo: [],
+      invitationCode: '',
+      rsvpStatus: 'pending',
     },
   });
+
+  const watchPlusOne = form.watch('plusOneAllowed');
 
   // Fetch user and wedding
   useEffect(() => {
@@ -153,7 +177,20 @@ export default function GuestsPage() {
   }, [weddingData]);
 
   const resetForm = () => {
-    form.reset({ name: '', email: '', phone: '', plusOneAllowed: false });
+    form.reset({
+      name: '',
+      email: '',
+      phone: '',
+      category: "bride's",
+      relationship: 'friend',
+      familyGroup: '',
+      headOfFamily: false,
+      plusOneAllowed: false,
+      plusOneName: '',
+      invitedTo: [],
+      invitationCode: '',
+      rsvpStatus: 'pending',
+    });
     setEditingGuest(null);
   };
 
@@ -167,7 +204,15 @@ export default function GuestsPage() {
           name: values.name,
           email: values.email || '',
           phone: values.phone || '',
+          category: values.category,
+          relationship: values.relationship,
+          familyGroup: values.familyGroup || '',
+          headOfFamily: values.headOfFamily,
           plusOneAllowed: values.plusOneAllowed,
+          plusOneName: values.plusOneName || '',
+          invitedTo: values.invitedTo || [],
+          invitationCode: values.invitationCode || '',
+          rsvpStatus: values.rsvpStatus,
           updatedAt: serverTimestamp(),
         });
         toast({ title: 'Guest updated' });
@@ -177,7 +222,15 @@ export default function GuestsPage() {
           name: values.name,
           email: values.email || '',
           phone: values.phone || '',
+          category: values.category,
+          relationship: values.relationship,
+          familyGroup: values.familyGroup || '',
+          headOfFamily: values.headOfFamily,
           plusOneAllowed: values.plusOneAllowed,
+          plusOneName: values.plusOneName || '',
+          invitedTo: values.invitedTo || [],
+          invitationCode: values.invitationCode || '',
+          rsvpStatus: values.rsvpStatus,
           createdAt: serverTimestamp(),
           updatedAt: serverTimestamp(),
         });
@@ -216,11 +269,32 @@ export default function GuestsPage() {
       name: guest.name || '',
       email: guest.email || '',
       phone: guest.phone || '',
+      category: guest.category || "bride's",
+      relationship: guest.relationship || 'friend',
+      familyGroup: guest.familyGroup || '',
+      headOfFamily: !!guest.headOfFamily,
       plusOneAllowed: !!guest.plusOneAllowed,
+      plusOneName: guest.plusOneName || '',
+      invitedTo: guest.invitedTo || [],
+      invitationCode: guest.invitationCode || '',
+      rsvpStatus: guest.rsvpStatus || 'pending',
     });
     setEditingGuest(guest);
     setDialogOpen(true);
   };
+
+  const filteredGuests = useMemo(
+    () =>
+      guests.filter((guest) => {
+        return (
+          guest.name.toLowerCase().includes(searchTerm.toLowerCase()) &&
+          (filters.category === 'all' || guest.category === filters.category) &&
+          (filters.relationship === 'all' || guest.relationship === filters.relationship) &&
+          (filters.rsvpStatus === 'all' || guest.rsvpStatus === filters.rsvpStatus)
+        );
+      }),
+    [guests, searchTerm, filters]
+  );
 
   if (isLoading) {
     return (
@@ -266,7 +340,7 @@ export default function GuestsPage() {
           <div className="flex items-center gap-3">
             <Users className="h-8 w-8 text-primary" />
             <div>
-              <h1 className="text-3xl md:text-4xl font-bold tracking-tight text-foreground">Guest List</h1>
+              <h1 className="text-3xl md:text-4xl font-bold tracking-tight text-foreground">Guest Management</h1>
               <p className="text-muted-foreground mt-1">Manage your wedding guests and their details.</p>
             </div>
           </div>
@@ -282,28 +356,84 @@ export default function GuestsPage() {
               </Button>
             </CardHeader>
             <CardContent>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-4">
+                <Input
+                  placeholder="Search by name..."
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                  className="h-10"
+                />
+                <select
+                  className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm"
+                  value={filters.category}
+                  onChange={(e) => setFilters((f) => ({ ...f, category: e.target.value }))}
+                >
+                  <option value="all">All Categories</option>
+                  <option value="bride's">Bride's Guest</option>
+                  <option value="bridegroom's">Bridegroom's Guest</option>
+                  <option value="shared">Shared Guest</option>
+                  <option value="service">Service Provider</option>
+                </select>
+                <select
+                  className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm"
+                  value={filters.relationship}
+                  onChange={(e) => setFilters((f) => ({ ...f, relationship: e.target.value }))}
+                >
+                  <option value="all">All Relationships</option>
+                  <option value="family">Family</option>
+                  <option value="friend">Friend</option>
+                  <option value="colleague">Colleague</option>
+                  <option value="service">Service</option>
+                </select>
+                <select
+                  className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm"
+                  value={filters.rsvpStatus}
+                  onChange={(e) => setFilters((f) => ({ ...f, rsvpStatus: e.target.value }))}
+                >
+                  <option value="all">All RSVP Statuses</option>
+                  <option value="pending">Pending</option>
+                  <option value="accepted">Accepted</option>
+                  <option value="declined">Declined</option>
+                </select>
+              </div>
               {loadingGuests ? (
                 <div className="flex justify-center py-10">
                   <Loader2 className="h-6 w-6 animate-spin" />
                 </div>
-              ) : guests.length === 0 ? (
-                <p className="text-muted-foreground">No guests have been added yet.</p>
+              ) : filteredGuests.length === 0 ? (
+                <p className="text-muted-foreground">No guests match your criteria.</p>
               ) : (
                 <Table>
                   <TableHeader>
                     <TableRow>
                       <TableHead>Name</TableHead>
-                      <TableHead>Email</TableHead>
-                      <TableHead>Phone</TableHead>
+                      <TableHead>Category</TableHead>
+                      <TableHead>Relationship</TableHead>
+                      <TableHead>Invited To</TableHead>
+                      <TableHead>RSVP</TableHead>
                       <TableHead className="text-right">Actions</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {guests.map((guest) => (
+                    {filteredGuests.map((guest) => (
                       <TableRow key={guest.id}>
                         <TableCell>{guest.name}</TableCell>
-                        <TableCell>{guest.email || '-'}</TableCell>
-                        <TableCell>{guest.phone || '-'}</TableCell>
+                        <TableCell className="capitalize">{guest.category?.replace("'", '’') || '-'}</TableCell>
+                        <TableCell className="capitalize">{guest.relationship || '-'}</TableCell>
+                        <TableCell className="capitalize">{guest.invitedTo?.join(', ').replace(/_/g, ' ') || '-'}</TableCell>
+                        <TableCell>
+                          <span
+                            className={`px-2 py-1 text-xs font-medium rounded-full ${
+                              guest.rsvpStatus === 'accepted'
+                                ? 'bg-green-100 text-green-800'
+                                : guest.rsvpStatus === 'declined'
+                                ? 'bg-red-100 text-red-800'
+                                : 'bg-yellow-100 text-yellow-800'
+                            }`}
+                          >
+                            {guest.rsvpStatus || 'pending'}
+                          </span>
+                        </TableCell>
                         <TableCell className="text-right">
                           <Button size="icon" variant="ghost" onClick={() => startEdit(guest)}>
                             <Edit className="h-4 w-4" />
@@ -392,6 +522,67 @@ export default function GuestsPage() {
                   />
                   <FormField
                     control={form.control}
+                    name="category"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Category</FormLabel>
+                        <FormControl>
+                          <select className="w-full h-10 rounded-md border border-input px-3" {...field}>
+                            <option value="bride's">Bride's Guest</option>
+                            <option value="bridegroom's">Bridegroom's Guest</option>
+                            <option value="shared">Shared Guest</option>
+                            <option value="service">Service Provider</option>
+                          </select>
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="relationship"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Relationship</FormLabel>
+                        <FormControl>
+                          <select className="w-full h-10 rounded-md border border-input px-3" {...field}>
+                            <option value="family">Family</option>
+                            <option value="friend">Friend</option>
+                            <option value="colleague">Colleague</option>
+                            <option value="service">Service</option>
+                          </select>
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="familyGroup"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Family Group</FormLabel>
+                        <FormControl>
+                          <Input placeholder="e.g., Smith Family" {...field} value={field.value || ''} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="headOfFamily"
+                    render={({ field }) => (
+                      <FormItem className="flex items-center space-x-2">
+                        <FormControl>
+                          <input type="checkbox" className="mr-2" checked={field.value} onChange={e => field.onChange(e.target.checked)} />
+                        </FormControl>
+                        <FormLabel>Head of Family</FormLabel>
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
                     name="plusOneAllowed"
                     render={({ field }) => (
                       <FormItem className="flex items-center space-x-2">
@@ -399,6 +590,73 @@ export default function GuestsPage() {
                           <input type="checkbox" className="mr-2" checked={field.value} onChange={e => field.onChange(e.target.checked)} />
                         </FormControl>
                         <FormLabel>Allow plus one</FormLabel>
+                      </FormItem>
+                    )}
+                  />
+                  {watchPlusOne && (
+                    <FormField
+                      control={form.control}
+                      name="plusOneName"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Plus-One Name</FormLabel>
+                          <FormControl>
+                            <Input placeholder="Plus one name" {...field} value={field.value || ''} />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  )}
+                  <div>
+                    <p className="text-sm font-medium">Invited To</p>
+                    <div className="flex flex-col space-y-1 pl-1 mt-1">
+                      {['ceremony', 'reception', 'welcome_dinner'].map((type) => (
+                        <label key={type} className="flex items-center space-x-2">
+                          <input
+                            type="checkbox"
+                            checked={form.getValues('invitedTo').includes(type)}
+                            onChange={() => {
+                              const current = form.getValues('invitedTo');
+                              if (current.includes(type)) {
+                                form.setValue('invitedTo', current.filter((t) => t !== type));
+                              } else {
+                                form.setValue('invitedTo', [...current, type]);
+                              }
+                            }}
+                          />
+                          <span className="capitalize">{type.replace('_', ' ')}</span>
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                  <FormField
+                    control={form.control}
+                    name="invitationCode"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Invitation Code</FormLabel>
+                        <FormControl>
+                          <Input placeholder="Auto-generated if blank" {...field} value={field.value || ''} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="rsvpStatus"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>RSVP Status</FormLabel>
+                        <FormControl>
+                          <select className="w-full h-10 rounded-md border border-input px-3" {...field}>
+                            <option value="pending">Pending</option>
+                            <option value="accepted">Accepted</option>
+                            <option value="declined">Declined</option>
+                          </select>
+                        </FormControl>
+                        <FormMessage />
                       </FormItem>
                     )}
                   />

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -177,7 +177,7 @@ export default function DashboardLayout({
           <SidebarGroup>
             <SidebarGroupLabel>Guests</SidebarGroupLabel>
             <SidebarMenu>
-              <NavLink href="/dashboard/guests" icon={<Users />} tooltip="Guest List">Guest List</NavLink>
+              <NavLink href="/dashboard/guests" icon={<Users />} tooltip="Guest Management">Guest Management</NavLink>
               <NavLink href="/dashboard/rsvps" icon={<ListChecks />} tooltip="RSVP Management">RSVP Management</NavLink>
               <NavLink href="/dashboard/invitations" icon={<Mail />} tooltip="Digital Invitations">Digital Invitations</NavLink>
             </SidebarMenu>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -74,7 +74,7 @@ const featuresData = [
   { icon: ListChecks, titleKey: "RSVP Management", descriptionKey: "Easily track guest responses, meal preferences, and plus-ones in real-time." },
   { icon: Camera, titleKey: "Photo Sharing", descriptionKey: "Allow guests to upload photos and create a beautiful shared gallery of memories." },
   { icon: Gift, titleKey: "Gift Registry Links", descriptionKey: "Integrate your gift registries and make it easy for guests to find your wish list." },
-  { icon: Users, titleKey: "Guest List Tools", descriptionKey: "Manage your guest list, seating arrangements, and communication effortlessly." },
+  { icon: Users, titleKey: "Guest Management Tools", descriptionKey: "Manage your guest list, seating arrangements, and communication effortlessly." },
   { icon: Palette, titleKey: "Theme Editor", descriptionKey: "Match your website to your wedding's color scheme and style with our intuitive editor." },
   { icon: Music, titleKey: "Playlist Collaboration", descriptionKey: "Let guests suggest songs and help create the perfect soundtrack for your celebration." },
   { icon: Share2, titleKey: "Easy Sharing", descriptionKey: "Share your wedding website link with guests via email, social media, or printed invitations." },

--- a/src/types/guest.ts
+++ b/src/types/guest.ts
@@ -7,6 +7,16 @@ export interface Guest {
   email?: string;
   phone?: string;
   plusOneAllowed?: boolean;
+  category?: "bride's" | "bridegroom's" | 'shared' | 'service';
+  relationship?: 'family' | 'friend' | 'colleague' | 'service';
+  familyGroup?: string;
+  headOfFamily?: boolean;
+  plusOneName?: string;
+  invitedTo?: string[];
+  invitationStatus?: 'sent' | 'not_sent';
+  rsvpStatus?: 'pending' | 'accepted' | 'declined';
+  mealChoice?: string | null;
+  invitationCode?: string;
   createdAt?: Timestamp;
   updatedAt?: Timestamp;
 }


### PR DESCRIPTION
## Summary
- extend `Guest` type with category, relationship, RSVP, etc
- update dashboard navigation and pages to use "Guest Management"
- implement search and filtering for guests
- expand guest form with category, relationship, and more fields

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run typecheck` *(fails: TS errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6841fd92a7b88332a58703d93c493670