### PR TITLE
Fix SidebarTrigger whitespace

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -218,12 +218,7 @@ export default function DashboardLayout({
       <SidebarInset className="flex flex-col">
          {isMobile && (
           <header className="sticky top-0 z-40 flex h-14 items-center gap-4 border-b bg-background px-4 sm:static sm:h-auto sm:border-0 sm:bg-transparent sm:px-6">
-            <SidebarTrigger asChild>
-                <Button size="icon" variant="outline" className="sm:hidden">
-                  <Menu className="h-5 w-5" />
-                  <span className="sr-only">Toggle Menu</span>
-                </Button>
-              </SidebarTrigger>
+            <SidebarTrigger asChild><Button size="icon" variant="outline" className="sm:hidden"><Menu className="h-5 w-5" /><span className="sr-only">Toggle Menu</span></Button></SidebarTrigger>
             <div className="flex-1">
                <Link href="/" className="flex items-center gap-2">
                 <Heart className="w-5 h-5 text-primary" />


### PR DESCRIPTION
## Summary
- fix SidebarTrigger usage when `asChild` by removing newline whitespace

## Testing
- `npm run lint` *(fails: prompts ESLint config)*
- `npm run typecheck` *(fails: TS2322, TS2769, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68420197a89483328b3dd637a4a9d378