### PR TITLE
Add digital invitation sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,15 @@
 This is a NextJS starter in Firebase Studio.
 
 To get started, take a look at src/app/page.tsx.
+
+## Digital Invitations
+
+Sending invitations requires SMTP credentials provided via environment variables:
+
+- `SMTP_HOST`
+- `SMTP_PORT`
+- `SMTP_USER`
+- `SMTP_PASS`
+- `SMTP_FROM` (optional, defaults to `SMTP_USER`)
+
+Add these to a `.env.local` file to enable email delivery.

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "genkit": "^1.6.2",
         "lucide-react": "^0.475.0",
         "next": "^15.3.3",
+        "nodemailer": "^6.10.1",
         "patch-package": "^8.0.0",
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
@@ -7629,6 +7630,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/normalize-path": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "genkit": "^1.6.2",
     "lucide-react": "^0.475.0",
     "next": "^15.3.3",
+    "nodemailer": "^6.10.1",
     "patch-package": "^8.0.0",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",

--- a/src/app/api/send-invitation/route.ts
+++ b/src/app/api/send-invitation/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server';
+import nodemailer from 'nodemailer';
+
+export async function POST(req: Request) {
+  try {
+    const { email, link, preview } = await req.json();
+    if (!email || !link) {
+      return NextResponse.json({ error: 'Missing email or link' }, { status: 400 });
+    }
+
+    const html = `<p>You are invited! Please visit <a href="${link}">${link}</a> for details.</p>`;
+
+    if (preview) {
+      return NextResponse.json({ success: true, html });
+    }
+
+    const transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: Number(process.env.SMTP_PORT || 587),
+      secure: process.env.SMTP_SECURE === 'true',
+      auth: {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS,
+      },
+    });
+
+    const info = await transporter.sendMail({
+      from: process.env.SMTP_FROM || process.env.SMTP_USER,
+      to: email,
+      subject: 'Wedding Invitation',
+      html,
+    });
+
+    return NextResponse.json({ success: true, messageId: info.messageId });
+  } catch (err: any) {
+    console.error('Error sending invitation:', err);
+    return NextResponse.json({ error: 'Failed to send invitation' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add nodemailer dependency
- implement `/api/send-invitation` API route for email delivery
- enable sending invitations from guest management
- document required SMTP environment variables

## Testing
- `npm run lint` *(fails: interactive prompt)*
- `npm run typecheck` *(fails: errors in other templates)*

------
https://chatgpt.com/codex/tasks/task_e_68422ba20794833295aeb6526446e7b2