### PR TITLE
Fix preview modal error when response is HTML

### DIFF
--- a/src/app/dashboard/guests/page.tsx
+++ b/src/app/dashboard/guests/page.tsx
@@ -394,8 +394,14 @@ const fetchInvitationPreview = async (guestToPreview: Guest) => {
         throw new Error(data.error || 'Preview HTML not found in response.');
       }
     } else {
-      const data = await res.json();
-      throw new Error(data.error || 'Failed to fetch preview.');
+      let message = res.statusText || 'Failed to fetch preview.';
+      try {
+        const data = await res.json();
+        if (data?.error) message = data.error;
+      } catch (err) {
+        // non-json response, ignore parsing error
+      }
+      throw new Error(message);
     }
   } catch (error: any) {
     console.error('Error fetching invitation preview:', error);


### PR DESCRIPTION
## Summary
- improve invitation preview error handling

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68435c2702288332a6bc6760823c0089