### PR TITLE
Add layout creator for seating plans

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "firebase": "^11.3.0",
         "geist": "^1.3.0",
         "genkit": "^1.6.2",
+        "konva": "^9.3.20",
         "lucide-react": "^0.475.0",
         "next": "^15.3.3",
         "nodemailer": "^6.10.1",
@@ -47,9 +48,11 @@
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.54.2",
+        "react-konva": "^19.0.5",
         "recharts": "^2.15.1",
         "tailwind-merge": "^3.0.1",
         "tailwindcss-animate": "^1.0.7",
+        "uuid": "^11.1.0",
         "zod": "^3.24.2"
       },
       "devDependencies": {
@@ -1175,6 +1178,19 @@
         "node-fetch": "^3.3.2",
         "partial-json": "^0.1.7",
         "uuid": "^10.0.0"
+      }
+    },
+    "node_modules/@genkit-ai/ai/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@genkit-ai/core": {
@@ -4201,14 +4217,12 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
-      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "devOptional": true
+      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ=="
     },
     "node_modules/@types/react": {
       "version": "18.3.18",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
-      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -4221,6 +4235,15 @@
       "devOptional": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.32.0.tgz",
+      "integrity": "sha512-+WHarFkJevhH1s655qeeSEf/yxFST0dVRsmSqUgxG8mMOKqycgYBv2wVpyubBY7MX8KiX5FQ03rNIwrxfm7Bmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/@types/request": {
@@ -6269,6 +6292,19 @@
         "node": ">=16"
       }
     },
+    "node_modules/genkit/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -7173,6 +7209,26 @@
       "dependencies": {
         "graceful-fs": "^4.1.11"
       }
+    },
+    "node_modules/konva": {
+      "version": "9.3.20",
+      "resolved": "https://registry.npmjs.org/konva/-/konva-9.3.20.tgz",
+      "integrity": "sha512-7XPD/YtgfzC8b1c7z0hhY5TF1IO/pBYNa29zMTA2PeBaqI0n5YplUeo4JRuRcljeAF8lWtW65jePZZF7064c8w==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/lavrton"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/konva"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/lavrton"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/kuler": {
       "version": "2.0.0",
@@ -8323,6 +8379,79 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
+    },
+    "node_modules/react-konva": {
+      "version": "19.0.5",
+      "resolved": "https://registry.npmjs.org/react-konva/-/react-konva-19.0.5.tgz",
+      "integrity": "sha512-Hu+nGXaWN9TtS2BHdXb4yKG0dV510HKubSdgeLYkynj2AeFq4Fwytr/czesCEPrMxXpTyWoY4px+vZHomJHlRQ==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/lavrton"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/konva"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/lavrton"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.32.0",
+        "its-fine": "^2.0.0",
+        "react-reconciler": "0.32.0",
+        "scheduler": "0.26.0"
+      },
+      "peerDependencies": {
+        "konva": "^8.0.1 || ^7.2.5 || ^9.0.0",
+        "react": "^18.3.1 || ^19.0.0",
+        "react-dom": "^18.3.1 || ^19.0.0"
+      }
+    },
+    "node_modules/react-konva/node_modules/its-fine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
+      "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.9"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
+    "node_modules/react-konva/node_modules/its-fine/node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/react-konva/node_modules/react-reconciler": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.32.0.tgz",
+      "integrity": "sha512-2NPMOzgTlG0ZWdIf3qG+dcbLSoAc/uLfOwckc3ofy5sSK0pLJqnQLpUFxvGcN2rlXSjnVtGeeFLNimCQEj5gOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.26.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-konva/node_modules/scheduler": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "license": "MIT"
     },
     "node_modules/react-remove-scroll": {
       "version": "2.6.3",
@@ -9681,15 +9810,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "firebase": "^11.3.0",
     "geist": "^1.3.0",
     "genkit": "^1.6.2",
+    "konva": "^9.3.20",
     "lucide-react": "^0.475.0",
     "next": "^15.3.3",
     "nodemailer": "^6.10.1",
@@ -51,9 +52,11 @@
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.54.2",
+    "react-konva": "^19.0.5",
     "recharts": "^2.15.1",
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",
+    "uuid": "^11.1.0",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/src/app/dashboard/seating/new/page.tsx
+++ b/src/app/dashboard/seating/new/page.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Stage, Layer, Rect, Circle, Group, Line } from 'react-konva';
+import { v4 as uuidv4 } from 'uuid';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Separator } from '@/components/ui/separator';
+import { Square, Circle as CircleIcon, ArrowLeft } from 'lucide-react';
+
+interface Chair {
+  id: string;
+  x: number;
+  y: number;
+}
+
+interface TableElement {
+  id: string;
+  type: 'rect' | 'circle';
+  x: number;
+  y: number;
+  width?: number;
+  height?: number;
+  radius?: number;
+  capacity: number;
+  chairs: Chair[];
+}
+
+export default function NewLayoutPage() {
+  const router = useRouter();
+  const [tables, setTables] = useState<TableElement[]>([]);
+  const [venueShape, setVenueShape] = useState<number[]>([]); // polygon points
+  const [drawingVenue, setDrawingVenue] = useState(false);
+
+  const handleAddRectangleTable = () => {
+    const cap = parseInt(prompt('Number of guests for this table?', '8') || '8', 10);
+    const width = 120;
+    const height = 60;
+    const { chairs } = generateRectChairs(width, height, cap);
+    setTables(t => [...t, { id: uuidv4(), type: 'rect', x: 200, y: 200, width, height, capacity: cap, chairs }]);
+  };
+
+  const handleAddCircleTable = () => {
+    const cap = parseInt(prompt('Number of guests for this table?', '8') || '8', 10);
+    const radius = 60;
+    const { chairs } = generateRoundChairs(radius, cap);
+    setTables(t => [...t, { id: uuidv4(), type: 'circle', x: 300, y: 300, radius, capacity: cap, chairs }]);
+  };
+
+  const generateRectChairs = (w: number, h: number, cap: number) => {
+    const chairs: Chair[] = [];
+    const perSide = Math.ceil(cap / 4);
+    const spacingX = w / (perSide + 1);
+    const spacingY = h / (perSide + 1);
+    for (let i = 0; i < perSide; i++) {
+      chairs.push({ id: uuidv4(), x: (i + 1) * spacingX - w / 2, y: -h / 2 - 20 }); // top
+      chairs.push({ id: uuidv4(), x: (i + 1) * spacingX - w / 2, y: h / 2 + 20 }); // bottom
+      chairs.push({ id: uuidv4(), x: -w / 2 - 20, y: (i + 1) * spacingY - h / 2 }); // left
+      chairs.push({ id: uuidv4(), x: w / 2 + 20, y: (i + 1) * spacingY - h / 2 }); // right
+    }
+    return { chairs: chairs.slice(0, cap) };
+  };
+
+  const generateRoundChairs = (r: number, cap: number) => {
+    const chairs: Chair[] = [];
+    for (let i = 0; i < cap; i++) {
+      const angle = (2 * Math.PI * i) / cap;
+      chairs.push({ id: uuidv4(), x: Math.cos(angle) * (r + 30), y: Math.sin(angle) * (r + 30) });
+    }
+    return { chairs };
+  };
+
+  const handleStageClick = (e: any) => {
+    if (!drawingVenue) return;
+    const stage = e.target.getStage();
+    const pointer = stage?.getPointerPosition();
+    if (!pointer) return;
+    setVenueShape(prev => [...prev, pointer.x, pointer.y]);
+  };
+
+  return (
+    <div className="flex flex-col gap-6 md:gap-8 h-[calc(100vh-8rem)]">
+      <div className="flex items-center gap-3">
+        <Button variant="outline" size="icon" onClick={() => router.back()}>
+          <ArrowLeft className="h-4 w-4" />
+        </Button>
+        <h1 className="text-2xl font-bold tracking-tight">Create Venue Layout</h1>
+      </div>
+      <div className="flex flex-grow gap-4 overflow-hidden">
+        <Card className="w-64 flex-shrink-0 shadow-md">
+          <CardHeader>
+            <CardTitle>Tools</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <Button className="w-full" onClick={handleAddRectangleTable}>
+              <Square className="mr-2 h-4 w-4" /> Add Rect Table
+            </Button>
+            <Button className="w-full" onClick={handleAddCircleTable}>
+              <CircleIcon className="mr-2 h-4 w-4" /> Add Round Table
+            </Button>
+            <Separator className="my-2" />
+            <Button
+              className="w-full"
+              variant={drawingVenue ? 'secondary' : 'outline'}
+              onClick={() => {
+                setVenueShape([]);
+                setDrawingVenue(d => !d);
+              }}
+            >
+              {drawingVenue ? 'Finish Venue Shape' : 'Draw Venue Shape'}
+            </Button>
+          </CardContent>
+        </Card>
+        <div className="flex-grow relative bg-muted/50 rounded-md overflow-hidden">
+          <Stage width={1000} height={700} onMouseDown={handleStageClick} className="bg-white">
+            <Layer>
+              {venueShape.length >= 4 && (
+                <Line points={venueShape} closed stroke="black" strokeWidth={2} fill="#f0f0f0" />
+              )}
+              {tables.map(table => (
+                <Group key={table.id} x={table.x} y={table.y} draggable>
+                  {table.type === 'rect' ? (
+                    <Rect
+                      width={table.width}
+                      height={table.height}
+                      fill="#ddd"
+                      stroke="black"
+                      strokeWidth={2}
+                      offset={{ x: (table.width || 0) / 2, y: (table.height || 0) / 2 }}
+                    />
+                  ) : (
+                    <Circle
+                      radius={table.radius}
+                      fill="#ddd"
+                      stroke="black"
+                      strokeWidth={2}
+                      offset={{ x: 0, y: 0 }}
+                    />
+                  )}
+                  {table.chairs.map(chair => (
+                    <Circle key={chair.id} x={chair.x} y={chair.y} radius={8} fill="#fff" stroke="black" />
+                  ))}
+                </Group>
+              ))}
+            </Layer>
+          </Stage>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/app/dashboard/seating/page.tsx
+++ b/src/app/dashboard/seating/page.tsx
@@ -400,8 +400,10 @@ export default function SeatingPage() {
             <Button variant="outline" disabled>
                 <ExternalLink className="mr-2 h-4 w-4" /> Request from Venue (Soon)
             </Button>
-            <Button disabled>
-                <PlusCircle className="mr-2 h-4 w-4" /> Create New Layout (Soon)
+            <Button asChild>
+                <Link href="/dashboard/seating/new">
+                    <PlusCircle className="mr-2 h-4 w-4" /> Create New Layout
+                </Link>
             </Button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add `react-konva` + `uuid` to manage interactive canvas elements
- implement `/dashboard/seating/new` page with a simple layout editor
- enable `Create New Layout` button to navigate to the new page

## Testing
- `npm run typecheck` *(fails: Timestamp type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68499a7022788332b3f204732df90cee