### PR TITLE
Fix Konva canvas issue in Next.js build

### DIFF
--- a/empty.js
+++ b/empty.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/next.config.ts
+++ b/next.config.ts
@@ -37,6 +37,17 @@ const nextConfigBase: NextConfig = {
       },
     ],
   },
+  webpack: config => {
+    config.externals = [...(config.externals || []), { canvas: 'canvas' }];
+    return config;
+  },
+  experimental: {
+    turbo: {
+      resolveAlias: {
+        canvas: './empty.js',
+      },
+    },
+  },
 };
 
 export default nextConfigBase;


### PR DESCRIPTION
## Summary
- alias `canvas` to an empty file for Turbopack
- add webpack externals for `canvas`
- create an empty `canvas` stub file

## Testing
- `npm run build` *(fails: useSearchParams should be wrapped in a suspense boundary)*

------
https://chatgpt.com/codex/tasks/task_e_6849aa57c4348332b86ba4fc6643244c