### PR TITLE
Fix transformer deselect issue

### DIFF
--- a/src/app/dashboard/seating/new/page.tsx
+++ b/src/app/dashboard/seating/new/page.tsx
@@ -230,6 +230,14 @@ export default function NewLayoutPage() {
         return;
     }
 
+    // If clicking on transformer anchors/handles, keep current selection
+    const isTransformer =
+      e.target.getClassName() === 'Transformer' ||
+      e.target.getParent()?.getClassName() === 'Transformer';
+    if (isTransformer) {
+        return;
+    }
+
     let node = e.target;
     // Traverse up to find a Konva.Group that has a table ID
     while (node && node !== stage) {


### PR DESCRIPTION
## Summary
- stop clearing selection when clicking Transformer handles in the seating layout editor

## Testing
- `npm run lint` *(fails: requires interactive configuration)*
- `npm run typecheck` *(fails: TS2769 errors)*

------
https://chatgpt.com/codex/tasks/task_e_684a003e771c8332a8c64f2804a07dcb