### PR TITLE
Fix table number text alignment

### DIFF
--- a/src/app/dashboard/seating/new/page.tsx
+++ b/src/app/dashboard/seating/new/page.tsx
@@ -763,26 +763,26 @@ export default function NewLayoutPage() {
                         }}
                     />
                   ))}
-                  <Text 
+                  <Text
                     text={`#${table.displayOrderNumber}`}
                     fontSize={fontSizeNumber}
                     fill="#3e2723"
                     fontStyle="bold"
-                    x={isCircle ? -tableWidthForText / 2 : 0}
-                    y={isCircle ? yPosNumberText : table.height / 2 + yPosNumberText}
-                    width={isCircle ? tableWidthForText : table.width}
+                    x={-tableWidthForText / 2}
+                    y={yPosNumberText}
+                    width={tableWidthForText}
                     height={textBlockRenderHeightNumber}
                     align="center"
                     verticalAlign="middle"
                     listening={false}
                   />
-                  <Text 
+                  <Text
                     text={`(${table.capacity}pp)`}
                     fontSize={fontSizeCapacity}
                     fill="#5d4037"
-                    x={isCircle ? -tableWidthForText / 2 : 0}
-                    y={isCircle ? yPosCapacityText : table.height / 2 + yPosCapacityText}
-                    width={isCircle ? tableWidthForText : table.width}
+                    x={-tableWidthForText / 2}
+                    y={yPosCapacityText}
+                    width={tableWidthForText}
                     height={textBlockRenderHeightCapacity}
                     align="center"
                     verticalAlign="middle"


### PR DESCRIPTION
## Summary
- center table number and capacity labels in the seating layout editor

## Testing
- `npm run lint` *(fails: requires interactive configuration)*
- `npm run typecheck` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_684aa9ecabf48332b4566cc8b1432179