### PR TITLE
Add interactive layout editing

### DIFF
--- a/src/app/dashboard/seating/page.tsx
+++ b/src/app/dashboard/seating/page.tsx
@@ -353,7 +353,7 @@ export default function SeatingPage() {
                <div className="flex justify-between items-center">
                 <CardDescription>Drag guests to tables. Max Capacity: {currentSelectedLayoutDetails.totalCapacity}</CardDescription>
                 <Button variant="outline" size="sm" asChild>
-                    <Link href={`/dashboard/seating/edit/${currentSelectedLayoutDetails.id}`}>
+                    <Link href={`/dashboard/seating/new?layoutId=${currentSelectedLayoutDetails.id}`}> 
                       <Edit className="mr-2 h-3 w-3"/> Edit This Layout
                     </Link>
                 </Button>
@@ -499,7 +499,7 @@ export default function SeatingPage() {
                  {layout.ownerId === currentUser?.uid && (
                     <div className="flex gap-2 mt-2">
                         <Button variant="outline" size="sm" className="w-full text-xs" asChild>
-                          <Link href={`/dashboard/seating/edit/${layout.id}`}>
+                          <Link href={`/dashboard/seating/new?layoutId=${layout.id}`}> 
                             <Edit className="mr-1.5 h-3 w-3" /> Edit
                           </Link>
                         </Button>

--- a/src/app/templates/wedding/base-template.tsx
+++ b/src/app/templates/wedding/base-template.tsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import type { Wedding } from '@/types/wedding';
+import type { Timestamp } from 'firebase/firestore';
 import { format } from 'date-fns';
 import { Heart } from 'lucide-react';
 import Image from 'next/image';
@@ -13,9 +14,16 @@ interface BaseTemplateProps {
   isPreviewMode?: boolean;
 }
 
+const toDate = (val?: Timestamp | string | Date | null) => {
+  if (!val) return undefined;
+  if (val instanceof Date) return val;
+  if (typeof val === 'string' || typeof val === 'number') return new Date(val);
+  return val.toDate();
+};
+
 const BaseTemplate: React.FC<BaseTemplateProps> = ({ wedding, children, isPreviewMode }) => {
   const formattedDate = wedding.date
-    ? format(new Date(wedding.date), "EEEE, MMMM do, yyyy 'at' h:mm a")
+    ? format(toDate(wedding.date)!, "EEEE, MMMM do, yyyy 'at' h:mm a")
     : 'Date to be announced';
 
   const titleClassName = isPreviewMode

--- a/src/app/templates/wedding/elegant-template.tsx
+++ b/src/app/templates/wedding/elegant-template.tsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import type { Wedding } from '@/types/wedding';
+import type { Timestamp } from 'firebase/firestore';
 import BaseTemplate from './base-template';
 import { greatVibes, cormorantGaramond } from '../../../lib/fonts'; 
 import { Calendar, MapPin, Heart, Camera, Users, Gift } from 'lucide-react';
@@ -12,6 +13,13 @@ interface ElegantTemplateProps {
   wedding: Partial<Wedding>;
   isPreviewMode?: boolean;
 }
+
+const toDate = (val?: Timestamp | string | Date | null) => {
+  if (!val) return undefined;
+  if (val instanceof Date) return val;
+  if (typeof val === 'string' || typeof val === 'number') return new Date(val);
+  return val.toDate();
+};
 
 const ElegantTemplate: React.FC<ElegantTemplateProps> = ({ wedding, isPreviewMode }) => {
   return (
@@ -31,7 +39,7 @@ const ElegantTemplate: React.FC<ElegantTemplateProps> = ({ wedding, isPreviewMod
                 <h3 className="text-lg sm:text-xl md:text-2xl font-semibold mb-3 text-card-foreground" style={{ fontFamily: "'Times New Roman', Times, serif" }}>Ceremony & Reception</h3>
                 <p className="text-base sm:text-lg text-muted-foreground mb-1">
                   {wedding.date
-                    ? new Date(wedding.date).toLocaleDateString('en-US', {
+                    ? toDate(wedding.date)?.toLocaleDateString('en-US', {
                         weekday: 'long',
                         year: 'numeric',
                         month: 'long',
@@ -41,7 +49,7 @@ const ElegantTemplate: React.FC<ElegantTemplateProps> = ({ wedding, isPreviewMod
                 </p>
                 <p className="text-base sm:text-lg text-muted-foreground">
                   {wedding.date
-                    ? new Date(wedding.date).toLocaleTimeString('en-US', {
+                    ? toDate(wedding.date)?.toLocaleTimeString('en-US', {
                         hour: 'numeric',
                         minute: '2-digit',
                         hour12: true,
@@ -135,7 +143,7 @@ const ElegantTemplate: React.FC<ElegantTemplateProps> = ({ wedding, isPreviewMod
               Will You Be Joining Us?
             </h2>
             <p className="text-lg sm:text-xl text-muted-foreground mb-6 md:mb-8">
-              Please RSVP by {wedding.rsvpDeadline ? new Date(wedding.rsvpDeadline).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }) : 'the deadline'} so we can finalize our arrangements.
+              Please RSVP by {wedding.rsvpDeadline ? toDate(wedding.rsvpDeadline)?.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }) : 'the deadline'} so we can finalize our arrangements.
             </p>
             <button className="px-8 sm:px-10 py-3 sm:py-4 bg-primary text-primary-foreground rounded-lg shadow-md hover:bg-primary/90 transition-colors text-base sm:text-lg font-semibold">
               RSVP Now

--- a/src/app/templates/wedding/modern-template.tsx
+++ b/src/app/templates/wedding/modern-template.tsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import type { Wedding } from '@/types/wedding';
+import type { Timestamp } from 'firebase/firestore';
 import BaseTemplate from './base-template'; 
 import { Calendar, MapPin, Heart, Camera, Music, Users, Gift, ListChecks } from 'lucide-react';
 import Image from 'next/image';
@@ -11,6 +12,13 @@ interface ModernTemplateProps {
   wedding: Partial<Wedding>;
   isPreviewMode?: boolean;
 }
+
+const toDate = (val?: Timestamp | string | Date | null) => {
+  if (!val) return undefined;
+  if (val instanceof Date) return val;
+  if (typeof val === 'string' || typeof val === 'number') return new Date(val);
+  return val.toDate();
+};
 
 const ModernTemplate: React.FC<ModernTemplateProps> = ({ wedding, isPreviewMode }) => {
   return (
@@ -32,14 +40,14 @@ const ModernTemplate: React.FC<ModernTemplateProps> = ({ wedding, isPreviewMode 
                 </div>
                 <p className="text-sm sm:text-base text-muted-foreground mb-1">
                   {wedding.date
-                    ? new Date(wedding.date).toLocaleDateString('en-US', {
+                    ? toDate(wedding.date)?.toLocaleDateString('en-US', {
                         weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
                       })
                     : 'Date TBA'}
                 </p>
                 <p className="text-sm sm:text-base text-muted-foreground">
                   {wedding.date
-                    ? new Date(wedding.date).toLocaleTimeString('en-US', {
+                    ? toDate(wedding.date)?.toLocaleTimeString('en-US', {
                         hour: 'numeric', minute: '2-digit', hour12: true,
                       })
                     : 'Time TBA'}
@@ -131,7 +139,7 @@ const ModernTemplate: React.FC<ModernTemplateProps> = ({ wedding, isPreviewMode 
             </div>
             <h2 className="text-2xl sm:text-3xl md:text-4xl font-bold mb-4 sm:mb-6">Join Our Celebration</h2>
             <p className="text-base sm:text-lg md:text-xl opacity-90 mb-8 md:mb-10 max-w-xl mx-auto">
-              We&apos;re excited to celebrate with you. Please let us know if you can make it by {wedding.rsvpDeadline ? new Date(wedding.rsvpDeadline).toLocaleDateString('en-US', { month: 'long', day: 'numeric' }) : 'the deadline'}!
+              We&apos;re excited to celebrate with you. Please let us know if you can make it by {wedding.rsvpDeadline ? toDate(wedding.rsvpDeadline)?.toLocaleDateString('en-US', { month: 'long', day: 'numeric' }) : 'the deadline'}!
             </p>
             <button className="px-8 sm:px-10 py-2 sm:py-3 bg-primary-foreground text-primary font-bold rounded-md shadow-lg hover:bg-background hover:text-foreground transition-colors text-base sm:text-lg">
               RSVP NOW

--- a/src/app/templates/wedding/rustic-template.tsx
+++ b/src/app/templates/wedding/rustic-template.tsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 import type { Wedding } from '@/types/wedding';
+import type { Timestamp } from 'firebase/firestore';
 import BaseTemplate from './base-template';
 import { nunitoSans, caveat } from '../../../lib/fonts'; 
 import { Calendar, MapPin, Heart, Users, Gift, Leaf, Clock, Camera } from 'lucide-react';
@@ -12,6 +13,13 @@ interface RusticTemplateProps {
   wedding: Partial<Wedding>;
   isPreviewMode?: boolean;
 }
+
+const toDate = (val?: Timestamp | string | Date | null) => {
+  if (!val) return undefined;
+  if (val instanceof Date) return val;
+  if (typeof val === 'string' || typeof val === 'number') return new Date(val);
+  return val.toDate();
+};
 
 const RusticTemplate: React.FC<RusticTemplateProps> = ({ wedding, isPreviewMode }) => {
   return (
@@ -40,14 +48,14 @@ const RusticTemplate: React.FC<RusticTemplateProps> = ({ wedding, isPreviewMode 
                   <h3 className="text-xl sm:text-2xl font-semibold mb-3 text-[#5d4037]" style={{ fontFamily: "'Times New Roman', Times, serif" }}>When</h3>
                   <p className="text-base sm:text-lg text-[#6d4c41] mb-1">
                     {wedding.date
-                      ? new Date(wedding.date).toLocaleDateString('en-US', {
+                      ? toDate(wedding.date)?.toLocaleDateString('en-US', {
                           weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
                         })
                       : 'Date to be announced'}
                   </p>
                   <p className="text-base sm:text-lg text-[#6d4c41]">
                     {wedding.date
-                      ? new Date(wedding.date).toLocaleTimeString('en-US', {
+                      ? toDate(wedding.date)?.toLocaleTimeString('en-US', {
                           hour: 'numeric', minute: '2-digit', hour12: true,
                         })
                       : 'Time to be announced'}
@@ -154,7 +162,7 @@ const RusticTemplate: React.FC<RusticTemplateProps> = ({ wedding, isPreviewMode 
               Will You Be There?
             </h2>
             <p className="text-base sm:text-lg text-[#5d4037] mb-6 md:mb-8 max-w-xl mx-auto">
-              We&apos;d be overjoyed to share our special day with you. Please let us know if you can make it by {wedding.rsvpDeadline ? new Date(wedding.rsvpDeadline).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric'}) : 'the deadline'}.
+              We&apos;d be overjoyed to share our special day with you. Please let us know if you can make it by {wedding.rsvpDeadline ? toDate(wedding.rsvpDeadline)?.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric'}) : 'the deadline'}.
             </p>
             <button className="px-8 sm:px-10 py-2 sm:py-3 bg-[#795548] text-white rounded-md shadow-lg hover:bg-[#6d4c41] transition-colors text-base sm:text-lg font-semibold">
               RSVP


### PR DESCRIPTION
## Summary
- enable interactive editing for venue layouts via `new` page when `layoutId` is provided
- link edit buttons to the updated editor
- handle timestamp conversions in wedding templates for type safety

## Testing
- `npm run typecheck` *(fails: Argument of type 'string | undefined' is not assignable to parameter of type 'string')*

------
https://chatgpt.com/codex/tasks/task_e_684c216854488332ab61be3875d1cb67