### PR TITLE
Add layout editing tools

### DIFF
--- a/src/types/venue.ts
+++ b/src/types/venue.ts
@@ -22,6 +22,7 @@ export interface TableElement {
   capacity: number; // Number of guests this table can accommodate
   chairs: Chair[]; // Array of chairs belonging to this table
   displayOrderNumber: number; // User-assigned number for display (e.g., Table #1)
+  label?: string; // Optional label for non-table elements like stages or stations
   // assignedGuests?: string[]; // Optional: For later when assigning guests
 }
 


### PR DESCRIPTION
## Summary
- display layout name while editing venue layouts
- extend `TableElement` model with optional label
- add special elements to the layout editor (candy bar, stage, etc.)
- allow deleting selected elements

## Testing
- `npm run typecheck` *(fails: TypeScript errors in unrelated files)*
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684c808b77c48332a24d880a1c549c55