### PR TITLE
Normalize layout values from Firestore

### DIFF
--- a/src/app/dashboard/seating/edit/[layoutId]/page.tsx
+++ b/src/app/dashboard/seating/edit/[layoutId]/page.tsx
@@ -14,6 +14,7 @@ import { ArrowLeft, Save, Loader2, Trash2, LayoutGrid as LayoutGridIcon, Square,
 import { auth, db, storage } from '@/lib/firebase-config';
 import { onAuthStateChanged, type User as FirebaseUser } from 'firebase/auth';
 import { doc, getDoc, updateDoc, serverTimestamp, deleteDoc } from 'firebase/firestore';
+import { normalizeVenueLayout } from '@/lib/utils';
 import { ref as storageRef, uploadBytesResumable, getDownloadURL, deleteObject as deleteFileObject } from "firebase/storage"; // Renamed to avoid conflict
 
 import type { VenueLayout, TableElement as StoredTableElement, Chair as StoredChair } from '@/types/venue'; // Use Stored types for clarity
@@ -312,8 +313,9 @@ export default function EditVenueLayoutPage() {
         const docRef = doc(db, 'venueLayouts', layoutId);
         const snap = await getDoc(docRef);
         if (snap.exists()) {
-          const data = ensureDateFields(snap.data()) as VenueLayout;
-           if (data.ownerId !== currentUserId) {
+          const raw = snap.data();
+          const data = normalizeVenueLayout(ensureDateFields(raw));
+          if (data.ownerId !== currentUserId) {
             toast({ title: 'Access Denied', description: 'You do not own this layout.', variant: 'destructive' });
             router.push('/dashboard/seating');
             return;

--- a/src/app/dashboard/seating/new/page.tsx
+++ b/src/app/dashboard/seating/new/page.tsx
@@ -38,6 +38,7 @@ import { useToast } from '@/hooks/use-toast';
 
 import { auth, db } from '@/lib/firebase-config'; // Import auth and db
 import { addDoc, collection, serverTimestamp, doc, getDoc, setDoc } from 'firebase/firestore';
+import { normalizeVenueLayout } from '@/lib/utils';
 import type { VenueLayout as StoredVenueLayout, TableElement as StoredTableElement, Chair as StoredChair } from '@/types/venue';
 
 
@@ -275,7 +276,8 @@ export default function NewLayoutPage() {
         const docRef = doc(db, 'venueLayouts', layoutId);
         const snap = await getDoc(docRef);
         if (snap.exists()) {
-          const data = snap.data() as StoredVenueLayout;
+          const raw = snap.data() as StoredVenueLayout;
+          const data = normalizeVenueLayout(raw);
           setTables(data.tables || []);
           setVenueShape(data.venueShape || []);
           setLayoutNameInput(data.name || '');

--- a/src/app/dashboard/seating/page.tsx
+++ b/src/app/dashboard/seating/page.tsx
@@ -33,6 +33,7 @@ import { onAuthStateChanged } from 'firebase/auth';
 import { collection, query, where, getDocs, doc, updateDoc, onSnapshot, orderBy, deleteDoc, Timestamp, or, serverTimestamp } from 'firebase/firestore';
 import type { Wedding } from '@/types/wedding';
 import type { VenueLayout, TableElement as VenueTableElement, Chair as VenueChair } from '@/types/venue';
+import { normalizeVenueLayout } from '@/lib/utils';
 import type { Guest } from '@/types/guest';
 
 const FONT_SIZE_NUMBER_RECT = 14;
@@ -155,7 +156,8 @@ export default function SeatingPage() {
       );
       const layoutSnapshot = await getDocs(qLayouts);
       const fetchedLayouts = layoutSnapshot.docs.map(doc => {
-        const data = doc.data();
+        const raw = doc.data();
+        const data = normalizeVenueLayout(raw);
         return {
           id: doc.id,
           ...data,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,48 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+// Normalize numeric fields for venue layouts fetched from Firestore
+// Firestore may return numbers or strings depending on how data was stored
+// This helper ensures we always work with proper numbers in the app
+import type { VenueLayout, TableElement, Chair } from '@/types/venue'
+
+export function normalizeVenueLayout(raw: any): VenueLayout {
+  const normalizeChair = (c: any): Chair => ({
+    id: c.id,
+    x: typeof c.x === 'string' ? parseFloat(c.x) : c.x ?? 0,
+    y: typeof c.y === 'string' ? parseFloat(c.y) : c.y ?? 0,
+  });
+
+  const normalizeTable = (t: any): TableElement => ({
+    id: t.id,
+    type: t.type,
+    x: typeof t.x === 'string' ? parseFloat(t.x) : t.x ?? 0,
+    y: typeof t.y === 'string' ? parseFloat(t.y) : t.y ?? 0,
+    width: typeof t.width === 'string' ? parseFloat(t.width) : t.width ?? 0,
+    height: typeof t.height === 'string' ? parseFloat(t.height) : t.height ?? 0,
+    radius:
+      t.radius !== undefined
+        ? typeof t.radius === 'string'
+          ? parseFloat(t.radius)
+          : t.radius
+        : undefined,
+    rotation: typeof t.rotation === 'string' ? parseFloat(t.rotation) : t.rotation ?? 0,
+    capacity: typeof t.capacity === 'string' ? parseInt(t.capacity, 10) : t.capacity ?? 0,
+    chairs: Array.isArray(t.chairs) ? t.chairs.map(normalizeChair) : [],
+    displayOrderNumber:
+      typeof t.displayOrderNumber === 'string'
+        ? parseInt(t.displayOrderNumber, 10)
+        : t.displayOrderNumber ?? 0,
+    label: t.label,
+  });
+
+  return {
+    ...raw,
+    tables: Array.isArray(raw.tables) ? raw.tables.map(normalizeTable) : [],
+    venueShape: Array.isArray(raw.venueShape)
+      ? raw.venueShape.map((v: any) => (typeof v === 'string' ? parseFloat(v) : v))
+      : [],
+  } as VenueLayout;
+}
+


### PR DESCRIPTION
## Summary
- normalize numeric layout fields when loading from Firestore
- use the new normalization helper in layout pages

## Testing
- `CI=true npm run lint` *(fails: prompts for ESLint config)*
- `npm run typecheck` *(fails: type errors in repo)*

------
https://chatgpt.com/codex/tasks/task_e_684d6102c63c8332815085861e86579d