### PR TITLE
Fix layout save errors with undefined fields

### DIFF
--- a/src/app/dashboard/seating/edit/[layoutId]/page.tsx
+++ b/src/app/dashboard/seating/edit/[layoutId]/page.tsx
@@ -702,9 +702,18 @@ export default function EditVenueLayoutPage() {
     setIsSavingStructure(true);
     const totalCapacity = editorTables.reduce((sum, table) => sum + table.capacity, 0);
     const tablesToStore: StoredTableElement[] = editorTables.map(currentTable => {
-      const tableData: Partial<StoredTableElement> = { ...currentTable, chairs: currentTable.chairs.map(chair => ({ ...chair } as StoredChair)) };
-      if (currentTable.type === 'circle' && typeof currentTable.radius === 'number') tableData.radius = currentTable.radius;
-      else delete tableData.radius;
+      const tableData: Partial<StoredTableElement> = {
+        ...currentTable,
+        chairs: currentTable.chairs.map(chair => ({ ...chair } as StoredChair))
+      };
+      if (currentTable.type === 'circle' && typeof currentTable.radius === 'number') {
+        tableData.radius = currentTable.radius;
+      } else {
+        delete tableData.radius;
+      }
+      if (currentTable.label === undefined) {
+        delete (tableData as any).label;
+      }
       return tableData as StoredTableElement;
     });
 

--- a/src/app/dashboard/seating/new/page.tsx
+++ b/src/app/dashboard/seating/new/page.tsx
@@ -597,17 +597,24 @@ export default function NewLayoutPage() {
     const totalCapacity = tables.reduce((sum, table) => sum + table.capacity, 0);
 
     const tablesToStore: StoredTableElement[] = tables.map(currentTable => {
-      const tableData: Partial<StoredTableElement> = { // Use Partial for constructing
+      const tableData: Partial<StoredTableElement> = {
         ...currentTable,
         chairs: currentTable.chairs.map(chair => ({ ...chair } as StoredChair))
       };
+
       // Only include radius if it's a circle and radius is a valid number
       if (currentTable.type === 'circle' && typeof currentTable.radius === 'number') {
         tableData.radius = currentTable.radius;
       } else {
-        delete tableData.radius; // Ensure radius is not undefined
+        delete tableData.radius;
       }
-      return tableData as StoredTableElement; // Cast to full type after construction
+
+      // Remove label if not present to avoid storing undefined
+      if (currentTable.label === undefined) {
+        delete (tableData as any).label;
+      }
+
+      return tableData as StoredTableElement;
     });
 
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -17,28 +17,35 @@ export function normalizeVenueLayout(raw: any): VenueLayout {
     y: typeof c.y === 'string' ? parseFloat(c.y) : c.y ?? 0,
   });
 
-  const normalizeTable = (t: any): TableElement => ({
-    id: t.id,
-    type: t.type,
-    x: typeof t.x === 'string' ? parseFloat(t.x) : t.x ?? 0,
-    y: typeof t.y === 'string' ? parseFloat(t.y) : t.y ?? 0,
-    width: typeof t.width === 'string' ? parseFloat(t.width) : t.width ?? 0,
-    height: typeof t.height === 'string' ? parseFloat(t.height) : t.height ?? 0,
-    radius:
-      t.radius !== undefined
-        ? typeof t.radius === 'string'
-          ? parseFloat(t.radius)
-          : t.radius
-        : undefined,
-    rotation: typeof t.rotation === 'string' ? parseFloat(t.rotation) : t.rotation ?? 0,
-    capacity: typeof t.capacity === 'string' ? parseInt(t.capacity, 10) : t.capacity ?? 0,
-    chairs: Array.isArray(t.chairs) ? t.chairs.map(normalizeChair) : [],
-    displayOrderNumber:
-      typeof t.displayOrderNumber === 'string'
-        ? parseInt(t.displayOrderNumber, 10)
-        : t.displayOrderNumber ?? 0,
-    label: t.label,
-  });
+  const normalizeTable = (t: any): TableElement => {
+    const table: TableElement = {
+      id: t.id,
+      type: t.type,
+      x: typeof t.x === 'string' ? parseFloat(t.x) : t.x ?? 0,
+      y: typeof t.y === 'string' ? parseFloat(t.y) : t.y ?? 0,
+      width: typeof t.width === 'string' ? parseFloat(t.width) : t.width ?? 0,
+      height: typeof t.height === 'string' ? parseFloat(t.height) : t.height ?? 0,
+      radius:
+        t.radius !== undefined
+          ? typeof t.radius === 'string'
+            ? parseFloat(t.radius)
+            : t.radius
+          : undefined,
+      rotation: typeof t.rotation === 'string' ? parseFloat(t.rotation) : t.rotation ?? 0,
+      capacity: typeof t.capacity === 'string' ? parseInt(t.capacity, 10) : t.capacity ?? 0,
+      chairs: Array.isArray(t.chairs) ? t.chairs.map(normalizeChair) : [],
+      displayOrderNumber:
+        typeof t.displayOrderNumber === 'string'
+          ? parseInt(t.displayOrderNumber, 10)
+          : t.displayOrderNumber ?? 0,
+    };
+
+    if (t.label !== undefined) {
+      table.label = t.label;
+    }
+
+    return table;
+  };
 
   return {
     ...raw,


### PR DESCRIPTION
## Summary
- strip undefined optional fields before storing tables
- keep `label` optional in `normalizeVenueLayout`

## Testing
- `npm run lint` *(fails: requires interactive setup)*
- `npm run typecheck` *(fails: multiple type errors)*

------
https://chatgpt.com/codex/tasks/task_e_684d70b383648332aab86e927654358c