### PR TITLE
Fix saving layout and remove preview image background

### DIFF
--- a/src/app/dashboard/seating/edit/[layoutId]/page.tsx
+++ b/src/app/dashboard/seating/edit/[layoutId]/page.tsx
@@ -692,6 +692,23 @@ export default function EditVenueLayoutPage() {
     });
   };
 
+  const refreshLayout = async () => {
+    if (!layoutId) return;
+    try {
+      const docRef = doc(db, 'venueLayouts', layoutId);
+      const snap = await getDoc(docRef);
+      if (snap.exists()) {
+        const raw = snap.data();
+        const data = normalizeVenueLayout(ensureDateFields(raw));
+        setLayout(data);
+        setEditorTables(data.tables || []);
+        setVenueShape(data.venueShape || []);
+      }
+    } catch (err) {
+      console.error('Failed to refresh layout', err);
+    }
+  };
+
   const handleSaveLayoutStructure = async () => {
     if (!layoutId || !currentUserId || !layout) {
       toast({ title: "Error", description: "Layout data or user session missing.", variant: "destructive" }); return;
@@ -730,7 +747,7 @@ export default function EditVenueLayoutPage() {
         { merge: true }
       );
       toast({ title: 'Layout Structure Updated', description: 'The visual layout has been saved.' });
-      setLayout(prev => prev ? { ...prev, tables: tablesToStore, totalCapacity } : null);
+      await refreshLayout();
     } catch (error: any) {
       console.error('Error saving layout structure:', error);
       toast({ title: 'Save Failed', description: error.message || 'Could not save layout structure.', variant: 'destructive' });

--- a/src/app/dashboard/seating/page.tsx
+++ b/src/app/dashboard/seating/page.tsx
@@ -562,14 +562,13 @@ export default function SeatingPage() {
                   height={stageDimensions.height}
                   className="bg-white rounded-b-md shadow-inner"
                   style={{
-                    backgroundImage: currentSelectedLayoutDetails.previewImageUrl
-                      ? `url(${currentSelectedLayoutDetails.previewImageUrl})`
-                      : 'linear-gradient(rgba(0,0,0,0.03) 1px, transparent 1px), linear-gradient(90deg, rgba(0,0,0,0.03) 1px, transparent 1px)',
-                    backgroundSize: currentSelectedLayoutDetails.previewImageUrl ? 'contain' : '20px 20px',
-                    backgroundRepeat: currentSelectedLayoutDetails.previewImageUrl ? 'no-repeat' : 'repeat',
-                    backgroundPosition: 'center'
+                    backgroundImage:
+                      'linear-gradient(rgba(0,0,0,0.03) 1px, transparent 1px), linear-gradient(90deg, rgba(0,0,0,0.03) 1px, transparent 1px)',
+                    backgroundSize: '20px 20px',
+                    backgroundRepeat: 'repeat',
+                    backgroundPosition: 'center',
                   }}
-                  data-ai-hint={currentSelectedLayoutDetails.previewImageUrl ? "venue layout" : "grid background"}
+                  data-ai-hint="grid background"
                 >
                   <Layer>
                     {/* Render Venue Elements */}


### PR DESCRIPTION
## Summary
- ensure edited layout is refreshed from Firestore after saving
- remove layout preview image from seating canvas background

## Testing
- `npm run lint` *(fails: asks how to configure ESLint)*
- `npm run typecheck` *(fails due to existing TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_684d861b1f8c8332859ba7fe9cb2b549