### PR TITLE
Fix table drag saving

### DIFF
--- a/src/app/dashboard/seating/edit/[layoutId]/page.tsx
+++ b/src/app/dashboard/seating/edit/[layoutId]/page.tsx
@@ -908,7 +908,6 @@ export default function EditVenueLayoutPage() {
                         <Group key={table.id} id={table.id} x={table.x} y={table.y} rotation={table.rotation} draggable={true} offsetX={0} offsetY={0}
                             ref={node => { if (node) tableNodeRefs.current.set(table.id, node); else tableNodeRefs.current.delete(table.id); }}
                             onDragEnd={(e) => {
-                                if (selectedTableId === table.id) return; 
                                 const newTables = editorTables.map(t => t.id === table.id ? { ...t, x: e.target.x(), y: e.target.y() } : t);
                                 const currentTableState = newTables.find(t => t.id === table.id);
                                 if (currentTableState) { const realignedChairs = alignChairsOnTable(currentTableState); setEditorTables(newTables.map(t => t.id === table.id ? { ...t, chairs: realignedChairs } : t));}

--- a/src/app/dashboard/seating/new/page.tsx
+++ b/src/app/dashboard/seating/new/page.tsx
@@ -786,8 +786,6 @@ export default function NewLayoutPage() {
                     }
                   }}
                   onDragEnd={(e) => {
-                    if (selectedTableId === table.id) { return; } 
-                    
                     const newTables = tables.map(t =>
                         t.id === table.id ? { ...t, x: e.target.x(), y: e.target.y() } : t
                     );


### PR DESCRIPTION
## Summary
- fix table drag-end logic so table positions are always saved

## Testing
- `npm run lint` *(fails: Next.js ESLint not configured)*
- `npm run build` *(fails: prerender error about missing suspense boundary)*
- `npm run typecheck` *(fails: numerous TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_684d8a7754408332933c28955a03c267