### PR TITLE
Fix flashing chairs during drag-and-drop

### DIFF
--- a/src/app/dashboard/seating/page.tsx
+++ b/src/app/dashboard/seating/page.tsx
@@ -85,16 +85,6 @@ export default function SeatingPage() {
     }
   }, [dragOverChairId]);
 
-  
-  useEffect(() => {
-    if (dragOverChairId) {
-      const interval = setInterval(() => setFlashToggle(prev => !prev), 300);
-      return () => clearInterval(interval);
-    } else {
-      setFlashToggle(false);
-    }
-  }, [dragOverChairId]);
-
 
   useEffect(() => {
     const updateDimensions = () => {


### PR DESCRIPTION
## Summary
- remove duplicate flash toggle effect so highlight updates

## Testing
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_684da123c5608332b692e59996d2eb9d