### PR TITLE
Add wedding planner module

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -34,6 +34,7 @@ import {
   Mail,
   ImageIcon,
   CalendarDays,
+  GanttChart,
   Palette,
   Heart,
   Music,
@@ -169,6 +170,7 @@ export default function DashboardLayout({
               <NavLink href="/dashboard/details" icon={<ScrollText />} tooltip="Wedding Details">Wedding Details</NavLink>
               <NavLink href="/dashboard/theme" icon={<Palette />} tooltip="Theme & Style">Theme & Style</NavLink>
               <NavLink href="/dashboard/schedule" icon={<CalendarDays />} tooltip="Event Schedule">Event Schedule</NavLink>
+              <NavLink href="/dashboard/planner" icon={<GanttChart />} tooltip="Planner">Planner</NavLink>
               <NavLink href="/dashboard/gallery" icon={<ImageIcon />} tooltip="Photo Gallery">Photo Gallery</NavLink>
             </SidebarMenu>
           </SidebarGroup>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -7,7 +7,9 @@ import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
-import { Clock, Users, ListChecks, PlusCircle, Eye, Edit, Heart, Loader2, LayoutDashboard } from 'lucide-react';
+import { Clock, Users, ListChecks, PlusCircle, Eye, Edit, Heart, Loader2, LayoutDashboard, GanttChart } from 'lucide-react';
+import { Progress } from '@/components/ui/progress';
+import { plannerTasks } from '@/lib/planner-data';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useToast } from '@/hooks/use-toast';
 
@@ -85,6 +87,15 @@ export default function DashboardPage() {
   const [declinedOtherGuestCount, setDeclinedOtherGuestCount] = useState(0);
 
   const [isLoadingStats, setIsLoadingStats] = useState(true);
+
+  const [plannerCompleted, setPlannerCompleted] = useState<Record<string, boolean>>({});
+  useEffect(() => {
+    const stored = localStorage.getItem('planner-completed');
+    if (stored) {
+      try { setPlannerCompleted(JSON.parse(stored)); } catch (_) {}
+    }
+  }, []);
+  const plannerProgress = Math.round((Object.keys(plannerCompleted).filter(k => plannerCompleted[k]).length / plannerTasks.length) * 100);
 
   const fetchWeddingAndGuestData = useCallback(async (user: User) => {
     setIsLoading(true);
@@ -450,6 +461,21 @@ export default function DashboardPage() {
                         )}
                     </>
                  )}
+              </CardContent>
+            </Card>
+            <Card className="shadow-md">
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium text-muted-foreground flex items-center">
+                  <GanttChart className="mr-2 h-4 w-4" />
+                  Planner Progress
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="mb-2 text-3xl font-bold text-foreground">{plannerProgress}%</div>
+                <Progress value={plannerProgress} />
+                <div className="mt-1 text-xs text-muted-foreground">
+                  <Link href="/dashboard/planner" className="underline">Open Planner</Link>
+                </div>
               </CardContent>
             </Card>
           </div>

--- a/src/app/dashboard/planner/page.tsx
+++ b/src/app/dashboard/planner/page.tsx
@@ -1,0 +1,211 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Progress } from '@/components/ui/progress';
+import { Skeleton } from '@/components/ui/skeleton';
+import { GanttChart, Heart, PlusCircle } from 'lucide-react';
+
+import { auth, db } from '@/lib/firebase-config';
+import type { User } from 'firebase/auth';
+import { onAuthStateChanged } from 'firebase/auth';
+import { collection, query, where, getDocs } from 'firebase/firestore';
+import type { Wedding } from '@/types/wedding';
+import type { PlannerTask } from '@/types/planner';
+import { plannerTasks } from '@/lib/planner-data';
+
+export default function PlannerPage() {
+  const router = useRouter();
+  const [currentUser, setCurrentUser] = useState<User | null>(null);
+  const [weddingData, setWeddingData] = useState<Wedding | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [completed, setCompleted] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    const stored = localStorage.getItem('planner-completed');
+    if (stored) {
+      try { setCompleted(JSON.parse(stored)); } catch (_) {}
+    }
+  }, []);
+
+  const toggleTask = (id: string) => {
+    setCompleted(prev => {
+      const next = { ...prev, [id]: !prev[id] };
+      localStorage.setItem('planner-completed', JSON.stringify(next));
+      return next;
+    });
+  };
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, async (user) => {
+      if (user) {
+        setCurrentUser(user);
+        try {
+          const weddingsRef = collection(db, 'weddings');
+          const q = query(weddingsRef, where('userId', '==', user.uid));
+          const querySnapshot = await getDocs(q);
+
+          if (!querySnapshot.empty) {
+            const weddingDoc = querySnapshot.docs[0];
+            setWeddingData({ id: weddingDoc.id, ...weddingDoc.data() } as Wedding);
+          } else {
+            setWeddingData(null);
+          }
+        } catch (error) {
+          console.error('Error fetching wedding data:', error);
+          setWeddingData(null);
+        }
+      } else {
+        setCurrentUser(null);
+        setWeddingData(null);
+        router.push('/auth');
+      }
+      setIsLoading(false);
+    });
+    return () => unsubscribe();
+  }, [router]);
+
+  const totalTasks = plannerTasks.length;
+  const completedCount = plannerTasks.filter(t => completed[t.id]).length;
+  const progressPercent = Math.round((completedCount / totalTasks) * 100);
+  const nextTask = plannerTasks.find(t => !completed[t.id]);
+
+  const baseStart = Math.min(...plannerTasks.map(t => t.startDays));
+  const ganttData = plannerTasks.map(t => ({
+    ...t,
+    offset: t.startDays - baseStart,
+  }));
+
+  const groupedTasks: Record<string, PlannerTask[]> = {};
+  plannerTasks.forEach(task => {
+    groupedTasks[task.phase] = groupedTasks[task.phase] || [];
+    groupedTasks[task.phase].push(task);
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-6 md:gap-8">
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-8 w-8 rounded-full" />
+          <div>
+            <Skeleton className="h-10 w-48 mb-2" />
+            <Skeleton className="h-5 w-72" />
+          </div>
+        </div>
+        <Card className="shadow-md">
+          <CardHeader>
+            <Skeleton className="h-8 w-1/3 mb-2" />
+            <Skeleton className="h-4 w-2/3" />
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-20 w-full" />
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6 md:gap-8">
+      {!weddingData ? (
+        <Card className="border-dashed border-2 p-8 text-center shadow-sm">
+          <Heart className="h-12 w-12 mx-auto text-primary/40 mb-4" />
+          <CardTitle className="text-xl font-semibold mb-2">No Wedding Site Yet</CardTitle>
+          <CardDescription className="text-muted-foreground mb-6 max-w-md mx-auto">
+            Please create your wedding site first to use the planner.
+          </CardDescription>
+          <Button asChild>
+            <Link href="/dashboard/details">
+              <PlusCircle className="mr-2 h-4 w-4" />
+              Create Your Wedding Site
+            </Link>
+          </Button>
+        </Card>
+      ) : (
+        <>
+          <div className="flex items-center gap-3">
+            <GanttChart className="h-8 w-8 text-primary" />
+            <div>
+              <h1 className="text-3xl md:text-4xl font-bold tracking-tight text-foreground">Wedding Planner</h1>
+              <p className="text-muted-foreground mt-1">
+                Track every step leading up to the big day.
+              </p>
+            </div>
+          </div>
+
+          <Card className="shadow-lg">
+            <CardHeader>
+              <CardTitle>Progress</CardTitle>
+              <CardDescription>
+                {progressPercent}% complete{nextTask ? ` – Next: ${nextTask.name}` : ''}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Progress value={progressPercent} />
+            </CardContent>
+          </Card>
+
+          <Tabs defaultValue="gantt">
+            <TabsList>
+              <TabsTrigger value="gantt">Gantt Chart</TabsTrigger>
+              <TabsTrigger value="todo">To-Do List</TabsTrigger>
+            </TabsList>
+            <TabsContent value="gantt" className="mt-4">
+              <div className="overflow-x-auto">
+                <div style={{ minWidth: 600 }}>
+                  <div className="relative space-y-1">
+                    {ganttData.map((task) => (
+                      <div key={task.id} className="flex items-center h-6 text-sm">
+                        <span className="w-48 pr-2 truncate">{task.name}</span>
+                        <div className="flex-1 relative h-2 bg-muted">
+                          <div
+                            className={
+                              task.critical
+                                ? 'absolute h-2 bg-destructive'
+                                : task.softCritical
+                                ? 'absolute h-2 bg-orange-500'
+                                : 'absolute h-2 bg-primary'
+                            }
+                            style={{
+                              left: `${(task.offset / 500) * 100}%`,
+                              width: `${(task.durationDays / 500) * 100}%`,
+                            }}
+                          />
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </TabsContent>
+            <TabsContent value="todo" className="mt-4">
+              {Object.entries(groupedTasks).map(([phase, tasks]) => (
+                <Card key={phase} className="mb-4">
+                  <CardHeader>
+                    <CardTitle>{phase}</CardTitle>
+                  </CardHeader>
+                  <CardContent className="space-y-3">
+                    {tasks.map((task) => (
+                      <label key={task.id} className="flex items-start space-x-2">
+                        <Checkbox checked={!!completed[task.id]} onCheckedChange={() => toggleTask(task.id)} />
+                        <span className="flex-1">
+                          {task.name}
+                          {task.critical ? ' (critical)' : task.softCritical ? ' (important)' : ''}
+                        </span>
+                      </label>
+                    ))}
+                  </CardContent>
+                </Card>
+              ))}
+            </TabsContent>
+          </Tabs>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/lib/planner-data.ts
+++ b/src/lib/planner-data.ts
@@ -1,0 +1,50 @@
+export interface PlannerTask {
+  id: string;
+  phase: string;
+  name: string;
+  startDays: number; // negative = before wedding, positive = after
+  durationDays: number;
+  critical?: boolean;
+  softCritical?: boolean;
+}
+
+export const plannerTasks: PlannerTask[] = [
+  { id: 'budget', phase: 'Getting Started', name: 'Define budget and guest count', startDays: -360, durationDays: 30, critical: true },
+  { id: 'theme', phase: 'Getting Started', name: 'Select wedding theme / style', startDays: -330, durationDays: 30 },
+  { id: 'planner', phase: 'Getting Started', name: 'Hire wedding planner (optional)', startDays: -360, durationDays: 30 },
+
+  { id: 'venue', phase: 'Core Bookings', name: 'Book venue', startDays: -360, durationDays: 60, critical: true },
+  { id: 'photo-video', phase: 'Core Bookings', name: 'Book photographer & videographer', startDays: -330, durationDays: 60, critical: true },
+  { id: 'band', phase: 'Core Bookings', name: 'Book band / DJ', startDays: -330, durationDays: 60, critical: true },
+  { id: 'catering', phase: 'Core Bookings', name: 'Book catering', startDays: -330, durationDays: 90, critical: true },
+  { id: 'officiant', phase: 'Core Bookings', name: 'Hire officiant', startDays: -300, durationDays: 60, critical: true },
+  { id: 'florist', phase: 'Core Bookings', name: 'Book florist', startDays: -270, durationDays: 60 },
+
+  { id: 'website', phase: 'Guest Communication', name: 'Create wedding website', startDays: -300, durationDays: 60, critical: true },
+  { id: 'save-date', phase: 'Guest Communication', name: 'Send "Save the Date"', startDays: -270, durationDays: 30, critical: true },
+  { id: 'guestlist', phase: 'Guest Communication', name: 'Finalize guest list', startDays: -240, durationDays: 60, critical: true },
+  { id: 'invitations', phase: 'Guest Communication', name: 'Send invitations', startDays: -180, durationDays: 30, critical: true },
+  { id: 'rsvps', phase: 'Guest Communication', name: 'Track RSVPs', startDays: -150, durationDays: 120, critical: true },
+
+  { id: 'dress', phase: 'Personal Preparations', name: 'Buy wedding dress', startDays: -300, durationDays: 120, critical: true },
+  { id: 'hair-makeup', phase: 'Personal Preparations', name: 'Book hair & makeup', startDays: -180, durationDays: 60 },
+  { id: 'rings', phase: 'Personal Preparations', name: 'Order wedding rings', startDays: -180, durationDays: 90, critical: true },
+  { id: 'transport', phase: 'Personal Preparations', name: 'Arrange transportation', startDays: -180, durationDays: 60 },
+  { id: 'honeymoon', phase: 'Personal Preparations', name: 'Plan honeymoon', startDays: -180, durationDays: 90 },
+  { id: 'first-dance', phase: 'Personal Preparations', name: 'Prepare first dance', startDays: -120, durationDays: 105, softCritical: true },
+  { id: 'rehearsal-dance', phase: 'Personal Preparations', name: 'Final dance rehearsal', startDays: -7, durationDays: 3, softCritical: true },
+
+  { id: 'menu', phase: 'Final Steps', name: 'Finalize menu and cake', startDays: -120, durationDays: 60, critical: true },
+  { id: 'dress-fitting', phase: 'Final Steps', name: 'Final dress fitting', startDays: -60, durationDays: 30, critical: true },
+  { id: 'confirm-vendors', phase: 'Final Steps', name: 'Confirm vendors', startDays: -60, durationDays: 30, critical: true },
+  { id: 'guest-headcount', phase: 'Final Steps', name: 'Final guest headcount', startDays: -30, durationDays: 14, critical: true },
+  { id: 'seating-chart', phase: 'Final Steps', name: 'Seating chart & place cards', startDays: -14, durationDays: 7, critical: true },
+  { id: 'wedding-rehearsal', phase: 'Final Steps', name: 'Wedding rehearsal', startDays: -2, durationDays: 1, critical: true },
+
+  { id: 'wedding-day', phase: 'Wedding Day', name: 'Wedding Day', startDays: 0, durationDays: 1, critical: true },
+
+  { id: 'upload-photos', phase: 'Post-Wedding', name: 'Upload photos & videos', startDays: 7, durationDays: 7 },
+  { id: 'thank-you', phase: 'Post-Wedding', name: 'Thank-you notes / website post', startDays: 7, durationDays: 7 },
+  { id: 'honeymoon-gallery', phase: 'Post-Wedding', name: 'Honeymoon gallery', startDays: 14, durationDays: 7 },
+  { id: 'guest-export', phase: 'Post-Wedding', name: 'Final guest export/report (optional)', startDays: 14, durationDays: 7 },
+];

--- a/src/types/planner.ts
+++ b/src/types/planner.ts
@@ -1,0 +1,9 @@
+export interface PlannerTask {
+  id: string;
+  phase: string;
+  name: string;
+  startDays: number;
+  durationDays: number;
+  critical?: boolean;
+  softCritical?: boolean;
+}


### PR DESCRIPTION
## Summary
- create planner data and types
- add Planner page under dashboard with Gantt and to-do views
- show planner progress widget on dashboard
- link planner in sidebar

## Testing
- `npm run lint` *(fails: prompts for setup)*
- `npm run typecheck` *(fails: type errors present)*

------
https://chatgpt.com/codex/tasks/task_e_684ea4d4822c83328ec702b6919dea11