### PR TITLE
Fix Wedding Planner scrollbars

### DIFF
--- a/src/app/dashboard/planner/page.tsx
+++ b/src/app/dashboard/planner/page.tsx
@@ -121,6 +121,21 @@ export default function PlannerPage() {
     }
   }, [containerWidth, chartStartDate, totalRange]);
 
+  useEffect(() => {
+    const mainEl = scrollRef.current?.closest('main');
+    const prevOverflow = mainEl?.style.overflowY;
+    if (mainEl) {
+      mainEl.style.overflowY = 'hidden';
+    }
+    document.body.classList.add('overflow-hidden');
+    return () => {
+      document.body.classList.remove('overflow-hidden');
+      if (mainEl) {
+        mainEl.style.overflowY = prevOverflow || '';
+      }
+    };
+  }, []);
+
   const ganttData = ganttTasks.map(t => ({
     ...t,
     offset: t.startDays - baseStart,


### PR DESCRIPTION
## Summary
- disable page-level scrolling on the planner page so only the Gantt chart can scroll

## Testing
- `npm run typecheck`
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68508b3c7a6c8332a96b1c25c9af4b99