### PR TITLE
Fix planner scroll behavior

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -231,7 +231,7 @@ export default function DashboardLayout({
             </div>
           </header>
         )}
-        <main className="flex-1 overflow-y-auto p-4 md:p-6 lg:p-8">
+        <main className="flex-1 overflow-hidden p-4 md:p-6 lg:p-8">
           {children}
         </main>
       </SidebarInset>

--- a/src/app/dashboard/planner/page.tsx
+++ b/src/app/dashboard/planner/page.tsx
@@ -167,7 +167,7 @@ export default function PlannerPage() {
   }
 
   return (
-    <div className="flex flex-col gap-6 md:gap-8 h-full overflow-hidden">
+    <div className="flex flex-col h-screen overflow-hidden">
       {!weddingData ? (
         <Card className="border-dashed border-2 p-8 text-center shadow-sm">
           <Heart className="h-12 w-12 mx-auto text-primary/40 mb-4" />
@@ -211,7 +211,7 @@ export default function PlannerPage() {
               <TabsTrigger value="gantt">Gantt Chart</TabsTrigger>
               <TabsTrigger value="todo">To-Do List</TabsTrigger>
             </TabsList>
-            <TabsContent value="gantt" className="mt-4 flex-1 overflow-hidden">
+            <TabsContent value="gantt" className="flex-1 overflow-hidden mt-4">
               <div ref={scrollRef} className="h-full overflow-auto">
                 <div
                   style={{ width: Math.max(600 + LABEL_WIDTH, totalRange * 10 + LABEL_WIDTH) }}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,11 +23,16 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" className="h-full" suppressHydrationWarning>
       <head />
-      <body className={`${GeistSans.variable} ${GeistMono.variable} antialiased`} suppressHydrationWarning>
-        {children}
-        <Toaster />
+      <body
+        className={`${GeistSans.variable} ${GeistMono.variable} antialiased h-full overflow-hidden`}
+        suppressHydrationWarning
+      >
+        <div className="min-h-screen flex flex-col h-full">
+          {children}
+          <Toaster />
+        </div>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- prevent body from scrolling by setting full-height html/body
- adjust dashboard main area to not scroll
- update planner page layout so only Gantt area scrolls

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68514fca64f0833281d1fcffe9c76f65