### PR TITLE
Fix Gantt chart horizontal scrolling

### DIFF
--- a/src/app/dashboard/planner/page.tsx
+++ b/src/app/dashboard/planner/page.tsx
@@ -212,8 +212,9 @@ export default function PlannerPage() {
               <TabsTrigger value="todo">To-Do List</TabsTrigger>
             </TabsList>
             <TabsContent value="gantt" className="flex-1 overflow-hidden mt-4">
-              <div ref={scrollRef} className="h-full overflow-auto">
+              <div ref={scrollRef} className="h-full overflow-x-auto overflow-y-auto">
                 <div
+                  className="min-w-[1500px]"
                   style={{ width: Math.max(600 + LABEL_WIDTH, totalRange * 10 + LABEL_WIDTH) }}
                   ref={ganttRef}
                 >


### PR DESCRIPTION
## Summary
- allow horizontal scroll in planner Gantt area
- ensure chart content is wide enough to overflow

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(interactive prompt prevents completion)*
- `npm run typecheck` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6851565e068c8332bfb2627d12a6a6c6