### PR TITLE
Fix planner layout scrolling issues

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -219,7 +219,7 @@ export default function DashboardLayout({
         </SidebarFooter>
       </Sidebar>
 
-      <SidebarInset className="flex flex-col">
+      <SidebarInset className="flex flex-col w-full max-w-screen overflow-x-hidden">
          {isMobile && (
           <header className="sticky top-0 z-40 flex h-14 items-center gap-4 border-b bg-background px-4 sm:static sm:h-auto sm:border-0 sm:bg-transparent sm:px-6">
             <SidebarTrigger asChild><Button size="icon" variant="outline" className="sm:hidden"><Menu className="h-5 w-5" /><span className="sr-only">Toggle Menu</span></Button></SidebarTrigger>
@@ -231,7 +231,7 @@ export default function DashboardLayout({
             </div>
           </header>
         )}
-        <main className="flex-1 overflow-hidden overflow-x-hidden p-4 md:p-6 lg:p-8">
+        <main className="flex-1 overflow-hidden overflow-x-hidden w-full max-w-screen p-4 md:p-6 lg:p-8">
           {children}
         </main>
       </SidebarInset>

--- a/src/app/dashboard/planner/page.tsx
+++ b/src/app/dashboard/planner/page.tsx
@@ -167,7 +167,7 @@ export default function PlannerPage() {
   }
 
   return (
-    <div className="flex flex-col flex-1 w-full overflow-x-hidden overflow-y-hidden">
+    <div className="flex flex-col flex-1 w-full max-w-screen overflow-x-hidden overflow-y-hidden">
       {!weddingData ? (
         <Card className="border-dashed border-2 p-8 text-center shadow-sm">
           <Heart className="h-12 w-12 mx-auto text-primary/40 mb-4" />
@@ -194,7 +194,7 @@ export default function PlannerPage() {
             </div>
           </div>
 
-          <Card className="shadow-lg">
+          <Card className="shadow-lg w-full max-w-screen">
             <CardHeader>
               <CardTitle>Progress</CardTitle>
               <CardDescription>
@@ -207,7 +207,7 @@ export default function PlannerPage() {
           </Card>
 
           <Tabs defaultValue="gantt" className="flex flex-col flex-1 overflow-hidden">
-            <TabsList>
+            <TabsList className="w-full max-w-screen">
               <TabsTrigger value="gantt">Gantt Chart</TabsTrigger>
               <TabsTrigger value="todo">To-Do List</TabsTrigger>
             </TabsList>


### PR DESCRIPTION
## Summary
- constrain main dashboard area to screen width
- prevent planner page overflow with width classes

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: interactive ESLint prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68516335df308332ab9f15d09e593456