### PR TITLE
Fix planner layout scroll chain

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -231,7 +231,7 @@ export default function DashboardLayout({
             </div>
           </header>
         )}
-        <main className="flex-1 overflow-hidden overflow-x-hidden w-full max-w-screen p-4 md:p-6 lg:p-8">
+        <main className="flex flex-col flex-1 overflow-hidden overflow-x-hidden w-full max-w-screen p-4 md:p-6 lg:p-8">
           {children}
         </main>
       </SidebarInset>


### PR DESCRIPTION
## Summary
- ensure dashboard layout `main` is a flex column so planner height fills container

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(prompts for configuration)*
- `npm run typecheck` *(fails: type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68516774aa448332b1f37e7d3a6a19c9