### PR TITLE
Fix Gantt row width

### DIFF
--- a/src/app/dashboard/planner/page.tsx
+++ b/src/app/dashboard/planner/page.tsx
@@ -453,7 +453,7 @@ export default function PlannerPage() {
                         </span>
                         <div
                           className="flex-1 relative h-4 bg-muted rounded"
-                          style={{ width: containerWidth }}
+                          style={{ minWidth: containerWidth }}
                         >
                           <Rnd
                             bounds="parent"


### PR DESCRIPTION
## Summary
- ensure activity slot background spans full chart width

## Testing
- `npm test` *(fails: jest not found)*
- `npm run typecheck` *(fails: missing types & other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68572742f3008332a53faf66275bd61f