### PR TITLE
Fix Gantt auto-scroll to today

### DIFF
--- a/src/app/dashboard/planner/page.tsx
+++ b/src/app/dashboard/planner/page.tsx
@@ -238,6 +238,13 @@ export default function PlannerPage() {
   }, [activeTab, containerWidth, totalRange, chartStartDate]);
 
   const hasScrolledRef = useRef(false);
+
+  // Reset scroll flag whenever the chart range changes so today's
+  // position is recalculated after data loads or tasks change.
+  useEffect(() => {
+    hasScrolledRef.current = false;
+  }, [chartStartDate, totalRange]);
+
   useLayoutEffect(() => {
     if (
       !hasScrolledRef.current &&


### PR DESCRIPTION
## Summary
- reset scroll flag whenever tasks or range changes so the chart recenters on today after data loads

## Testing
- `npm run lint` *(fails: prompts for config)*
- `npm run typecheck` *(fails: TypeScript errors)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68583a3c701483329f40d4f3efe250bd