### PR TITLE
Fix Gantt chart scroll behavior

### DIFF
--- a/src/app/dashboard/planner/page.tsx
+++ b/src/app/dashboard/planner/page.tsx
@@ -231,35 +231,20 @@ export default function PlannerPage() {
     };
   }, [activeTab]);
 
-  useEffect(() => {
-    if (activeTab === 'gantt') {
-      scrollToToday();
-    }
-  }, [activeTab, containerWidth, totalRange, chartStartDate]);
-
-  const hasScrolledRef = useRef(false);
-
-  // Reset scroll flag whenever the chart range changes so today's
-  // position is recalculated after data loads or tasks change.
-  useEffect(() => {
-    hasScrolledRef.current = false;
-  }, [chartStartDate, totalRange]);
+  const initialScrolledRef = useRef(false);
 
   useLayoutEffect(() => {
     if (
-      !hasScrolledRef.current &&
+      activeTab === 'gantt' &&
+      !initialScrolledRef.current &&
       containerWidth > 0 &&
       scrollRef.current &&
       totalRange > 0
     ) {
-      const todayOffset = differenceInCalendarDays(startOfToday(), chartStartDate);
-      scrollRef.current.scrollLeft =
-        (todayOffset / totalRange) * containerWidth +
-        LABEL_WIDTH -
-        scrollRef.current.clientWidth / 2;
-      hasScrolledRef.current = true;
+      scrollToToday();
+      initialScrolledRef.current = true;
     }
-  }, [containerWidth, totalRange, chartStartDate]);
+  }, [activeTab, containerWidth, totalRange, chartStartDate]);
 
   const ganttData = ganttTasks.map(t => ({
     ...t,


### PR DESCRIPTION
## Summary
- only auto-scroll to today when the Gantt chart loads

## Testing
- `npm run lint` *(fails: interactive prompt)*
- `npm run typecheck` *(fails: type errors in repo)*
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68591187d6c48332b0554202ca7f2f93